### PR TITLE
Use optimized #fast_insert in Utxo backend

### DIFF
--- a/lib/bitcoin/blockchain/backends/archive/archive.rb
+++ b/lib/bitcoin/blockchain/backends/archive/archive.rb
@@ -521,50 +521,6 @@ module Bitcoin::Blockchain::Backends
       txouts.inject(0){ |m, out| m + out.value }
     end
 
-    protected
-
-    # Abstraction for doing many quick inserts.
-    #
-    # * +table+ - db table name
-    # * +data+ - a table of hashes with the same keys
-    # * +opts+
-    # ** return_ids - if true table of inserted rows ids will be returned
-    def fast_insert(table, data, opts={})
-      return [] if data.empty?
-      # For postgres we are using COPY which is much faster than separate INSERTs
-      if @db.adapter_scheme == :postgres
-
-        columns = data.first.keys
-        if opts[:return_ids]
-          ids = db.transaction do
-            # COPY does not return ids, so we set ids manually based on current sequence value
-            # We lock the table to avoid inserts that could happen in the middle of COPY
-            db.execute("LOCK TABLE #{table} IN SHARE UPDATE EXCLUSIVE MODE")
-            first_id = db.fetch("SELECT nextval('#{table}_id_seq') AS id").first[:id]
-
-            # Blobs need to be represented in the hex form (yes, we do hth on them earlier, could be improved
-            # \\x is the format of bytea as hex encoding in postgres
-            csv = data.map.with_index{|x,i| [first_id + i, columns.map{|c| x[c].kind_of?(Sequel::SQL::Blob) ? "\\x#{x[c].hth}" : x[c]}].join(',')}.join("\n")
-            db.copy_into(table, columns: [:id] + columns, format: :csv, data: csv)
-            last_id = first_id + data.size - 1
-
-            # Set sequence value to max id, last arg true means it will be incremented before next value
-            db.execute("SELECT setval('#{table}_id_seq', #{last_id}, true)")
-            (first_id..last_id).to_a # returned ids
-          end
-        else
-          csv = data.map{|x| columns.map{|c| x[c].kind_of?(Sequel::SQL::Blob) ? "\\x#{x[c].hth}" : x[c]}.join(',')}.join("\n")
-          @db.copy_into(table, format: :csv, columns: columns, data: csv)
-        end
-
-      else
-
-        # Life is simple when your are not optimizing ;)
-        @db[table].insert_multiple(data)
-
-      end
-    end
-
   end
 
 end

--- a/lib/bitcoin/blockchain/backends/utxo/utxo.rb
+++ b/lib/bitcoin/blockchain/backends/utxo/utxo.rb
@@ -16,19 +16,24 @@ module Bitcoin::Blockchain::Backends
     attr_accessor :db
 
     DEFAULT_CONFIG = {
+
       # cache head block; it is only updated when new block comes in,
       # so this should only be used by the store receiving new blocks.
       cache_head: false,
+
       # cache this many utxo records before syncing to disk.
       # this should only be enabled during initial sync, because
       # with it the store cannot reorg properly.
       utxo_cache: 250,
+
       # cache this many blocks.
       # NOTE: this is also the maximum number of blocks the store can reorg.
       block_cache: 120,
+
       # keep an index of utxos for all addresses, not just the ones
       # we are explicitly told about.
       index_all_addrs: false
+
     }
 
     # create sequel store with given +config+
@@ -159,7 +164,7 @@ module Bitcoin::Blockchain::Backends
 
     def flush_new_outs
       log.time "flushed #{@new_outs.size} new txouts in %.4fs" do
-        new_utxo_ids = @db[:utxo].insert_multiple(@new_outs.map{|o|o[0]})
+        new_utxo_ids = fast_insert :utxo, @new_outs.map(&:first), return_ids: true
         @new_outs.each.with_index do |d, idx|
           d[1].each do |i, hash160|
             next  unless i && hash160


### PR DESCRIPTION
This, together with #3 gets the benchmark from 77 seconds down to 24!

But after a benchmark the database seems to be a little bit bigger (with #3 alone, it's 30.991.160 bytes, with this change added, 31.023.928).
